### PR TITLE
Include stdlib.h

### DIFF
--- a/waive.c
+++ b/waive.c
@@ -25,6 +25,7 @@
 #include <sys/socket.h>
 #include <sys/mman.h>
 #include <errno.h>
+#include <stdlib.h>
 
 #include <seccomp.h>
 

--- a/waive.c
+++ b/waive.c
@@ -25,7 +25,7 @@
 #include <sys/socket.h>
 #include <sys/mman.h>
 #include <errno.h>
-#include <stdlib.h>
+#include <stddef.h>
 
 #include <seccomp.h>
 


### PR DESCRIPTION
NULL is declared in stdlib.h, and without it being included, I am unable to compile, getting the following error:

waive.c:39:6: error: ‘NULL’ undeclared (first use in this function)
  if (NULL == ctx)

For this reason, I think that stdlib.h should be included. I have tested this patch and it enables me to compile.
